### PR TITLE
Feature/promisify

### DIFF
--- a/packages/dataparcels-docs/src/pages/dev.js
+++ b/packages/dataparcels-docs/src/pages/dev.js
@@ -1,41 +1,53 @@
 // @flow
 import React from 'react';
+import {useRef} from 'react';
 import Page from 'component/Page';
 import {H1} from 'dcme-style';
 import {ContentNav} from 'dcme-style';
 
-import useParcelState from 'react-dataparcels/useParcelState';
-import ParcelBoundary from 'react-dataparcels/ParcelBoundary';
+import promisify from 'react-dataparcels/promisify';
+import useParcel from 'react-dataparcels/useParcel';
+import Boundary from 'react-dataparcels/Boundary';
 
 export default function PersonEditor() {
 
-    let [personParcel] = useParcelState({
-        value: {
-            firstname: "Robert",
-            lastname: "Clamps"
-        }
-    });
+    let rejectRef = useRef();
 
-    personParcel = personParcel
-        .modifyUp(({changeRequest}) => {
-            // cause the change request reducer to re-execute the same effect again
-            changeRequest.nextData;
-        })
-        .modifyUp(({value}) => {
-            let {firstname} = value;
+    let personParcel = useParcel({
+        // source: () => ({
+        //     value: {
+        //         firstname: "Robert",
+        //         lastname: "Clamps",
+        //         saves: 0
+        //     }
+        // }),
+        source: promisify('load', async () => {
+            await new Promise(resolve => setTimeout(resolve, 1000));
             return {
-                effect: async (update) => {
-                    await new Promise(resolve => setTimeout(resolve, firstname.length > 2 ? 0 : 1000));
-
-                    update(({value}) => ({
-                        value: {
-                            ...value,
-                            lastname: firstname
-                        }
-                    }));
+                value: {
+                    firstname: "Robert",
+                    lastname: "Clamps",
+                    saves: 0
                 }
             };
-        });
+        }),
+        onChange: promisify('save', async ({value}) => {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            if(rejectRef.current) {
+                rejectRef.current = false;
+                throw new Error('NO!!!');
+            }
+
+            return {
+                value: {
+                    ...value,
+                    saves: value.saves + 1
+                }
+            };
+        }),
+        buffer: true
+    });
 
     return <Page>
         <ContentNav
@@ -44,15 +56,32 @@ export default function PersonEditor() {
             mdxHeading
         >
             <H1>Dev page</H1>
-            <label>firstname</label>
-            <ParcelBoundary parcel={personParcel.get('firstname')}>
-                {(firstname) => <input type="text" {...firstname.spreadInput()} />}
-            </ParcelBoundary>
+            <div>load status {personParcel.meta.loadStatus}</div>
 
-            <label>lastname</label>
-            <ParcelBoundary parcel={personParcel.get('lastname')}>
-                {(lastname) => <input type="text" {...lastname.spreadInput()} />}
-            </ParcelBoundary>
+            {personParcel.value &&
+                <>
+                    <div>firstname</div>
+                    <Boundary source={personParcel.get('firstname')}>
+                        {(firstname) => <input type="text" {...firstname.spreadInput()} />}
+                    </Boundary>
+
+                    <div>lastname</div>
+                    <Boundary source={personParcel.get('lastname')}>
+                        {(lastname) => <input type="text" {...lastname.spreadInput()} />}
+                    </Boundary>
+
+                    <div>save status {personParcel.meta.saveStatus}</div>
+                    <div>save error {personParcel.meta.saveError && personParcel.meta.saveError.message}</div>
+                    <div>saves {personParcel.value.saves}</div>
+
+                    <div>
+                        <button onClick={personParcel.meta.submit}>submit</button>
+                    </div>
+                    <div>
+                        <button onClick={() => {rejectRef.current = true;}}>reject</button>
+                    </div>
+                </>
+            }
         </ContentNav>
     </Page>;
 }

--- a/packages/dataparcels-docs/src/pages/dev.js
+++ b/packages/dataparcels-docs/src/pages/dev.js
@@ -21,30 +21,37 @@ export default function PersonEditor() {
         //         saves: 0
         //     }
         // }),
-        source: promisify('load', async () => {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            return {
-                value: {
-                    firstname: "Robert",
-                    lastname: "Clamps",
-                    saves: 0
-                }
-            };
-        }),
-        onChange: promisify('save', async ({value}) => {
-            await new Promise(resolve => setTimeout(resolve, 1000));
-
-            if(rejectRef.current) {
-                rejectRef.current = false;
-                throw new Error('NO!!!');
+        source: promisify({
+            key: 'load',
+            effect: async () => {
+                await new Promise(resolve => setTimeout(resolve, 1000));
+                return {
+                    value: {
+                        firstname: "Robert",
+                        lastname: "Clamps",
+                        saves: 0
+                    }
+                };
             }
+        }),
+        onChange: promisify({
+            key: 'save',
+            effect: async ({value}) => {
+                await new Promise(resolve => setTimeout(resolve, 1000));
 
-            return {
-                value: {
-                    ...value,
-                    saves: value.saves + 1
+                if(rejectRef.current) {
+                    rejectRef.current = false;
+                    throw new Error('NO!!!');
                 }
-            };
+
+                return {
+                    value: {
+                        ...value,
+                        saves: value.saves + 1
+                    }
+                };
+            },
+            revert: true
         }),
         buffer: true
     });

--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -32,6 +32,10 @@
         "path": "arrange.js"
     },
     {
+        "limit": "0.5 KB",
+        "path": "promisify.js"
+    },
+    {
         "limit": "2.2 KB",
         "path": "translate.js"
     },

--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -32,7 +32,7 @@
         "path": "arrange.js"
     },
     {
-        "limit": "0.5 KB",
+        "limit": "0.6 KB",
         "path": "promisify.js"
     },
     {

--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -32,7 +32,7 @@
         "path": "arrange.js"
     },
     {
-        "limit": "0.6 KB",
+        "limit": "0.7 KB",
         "path": "promisify.js"
     },
     {

--- a/packages/dataparcels/__test__/Exports-test.js
+++ b/packages/dataparcels/__test__/Exports-test.js
@@ -9,6 +9,7 @@ import deleted from '../deleted';
 import ParcelNode from '../ParcelNode';
 import arrange from '../arrange';
 import cancel from '../cancel';
+import promisify from '../promisify';
 import translate from '../translate';
 import validation from '../validation';
 
@@ -23,6 +24,7 @@ import Internaldeleted from '../lib/parcelData/deleted';
 import InternalParcelNode from '../lib/parcelNode/ParcelNode';
 import InternalAsNodes from '../lib/parcelNode/arrange';
 import Internalcancel from '../lib/change/cancel';
+import InternalPromisify from '../lib/modifiers/promisify';
 import InternalTranslate from '../lib/modifiers/translate';
 import InternalValidation from '../lib/validation/validation';
 
@@ -56,6 +58,10 @@ test('/arrange should export arrange', () => {
 
 test('/cancel should export cancel', () => {
     expect(cancel).toBe(Internalcancel);
+});
+
+test('/promisify should export promisify', () => {
+    expect(promisify).toBe(InternalPromisify);
 });
 
 test('/translate should export translate', () => {

--- a/packages/dataparcels/package.json
+++ b/packages/dataparcels/package.json
@@ -18,6 +18,7 @@
     "combine.js",
     "deleted.js",
     "ParcelNode.js",
+    "promisify.js",
     "translate.js",
     "validation.js"
   ],

--- a/packages/dataparcels/promisify.js
+++ b/packages/dataparcels/promisify.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('./lib/modifiers/promisify.js').default;

--- a/packages/dataparcels/src/modifiers/__test__/promisify-test.js
+++ b/packages/dataparcels/src/modifiers/__test__/promisify-test.js
@@ -18,7 +18,10 @@ describe('promisify', () => {
         });
 
         let promisifiedParcel = parcel
-            .modifyUp(promisify('foo', () => Promise.resolve()));
+            .modifyUp(promisify({
+                key: 'foo',
+                effect: () => Promise.resolve()
+            }));
 
         expect(promisifiedParcel.value).toBe(123);
         expect(promisifiedParcel.meta.fooStatus).toBe(undefined);
@@ -58,9 +61,12 @@ describe('promisify', () => {
         });
 
         parcel
-            .modifyUp(promisify('foo', ({value}) => Promise.resolve({
-                value: value + 1
-            })))
+            .modifyUp(promisify({
+                key: 'foo',
+                effect: ({value}) => Promise.resolve({
+                    value: value + 1
+                })
+            }))
             .set(456);
 
         await Promise.resolve();
@@ -88,7 +94,10 @@ describe('promisify', () => {
         });
 
         parcel
-            .modifyUp(promisify('foo', () => Promise.reject('error!')))
+            .modifyUp(promisify({
+                key: 'foo',
+                effect: () => Promise.reject('error!')
+            }))
             .set(456);
 
         await Promise.resolve();
@@ -127,16 +136,19 @@ describe('promisify', () => {
             resolveSecondPromise = () => reject('second-rejected');
         });
 
-        let promiseUpdater = promisify('foo', ({value}) => {
-            if(value === 'first') {
-                return firstPromise;
+        let promiseUpdater = promisify({
+            key: 'foo',
+            effect: ({value}) => {
+                if(value === 'first') {
+                    return firstPromise;
+                }
+                if(value === 'second') {
+                    return secondPromise;
+                }
+                return Promise.resolve({
+                    value: 'third-resolved'
+                });
             }
-            if(value === 'second') {
-                return secondPromise;
-            }
-            return Promise.resolve({
-                value: 'third-resolved'
-            });
         });
 
         parcel

--- a/packages/dataparcels/src/modifiers/__test__/promisify-test.js
+++ b/packages/dataparcels/src/modifiers/__test__/promisify-test.js
@@ -1,0 +1,171 @@
+// @flow
+import promisify from '../promisify';
+import Parcel from '../../parcel/Parcel';
+
+describe('promisify', () => {
+    it('should fire promise and resolve', async () => {
+
+        // remove setTimeout because jest doesnt handle
+        // setTimeouts and promises all mixed together like this
+        let realSetTimeout = window.setTimeout;
+        window.setTimeout = (fn, ms) => fn();
+
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        let promisifiedParcel = parcel
+            .modifyUp(promisify('foo', () => Promise.resolve()));
+
+        expect(promisifiedParcel.value).toBe(123);
+        expect(promisifiedParcel.meta.fooStatus).toBe(undefined);
+        expect(promisifiedParcel.meta.fooError).toBe(undefined);
+
+        promisifiedParcel.set(456);
+
+        expect(handleChange).toHaveBeenCalledTimes(1);
+
+        let newParcel = handleChange.mock.calls[0][0];
+        expect(newParcel.value).toBe(456);
+        expect(newParcel.meta.fooStatus).toBe('pending');
+        expect(newParcel.meta.fooError).toBe(undefined);
+
+        await Promise.resolve();
+
+        expect(handleChange).toHaveBeenCalledTimes(2);
+        expect(handleChange.mock.calls[1][0].value).toBe(456);
+        expect(handleChange.mock.calls[1][0].meta.fooStatus).toBe('resolved');
+        expect(handleChange.mock.calls[1][0].meta.fooError).toBe(undefined);
+
+        window.setTimeout = realSetTimeout;
+    });
+
+    it('should fire promise and resolve with updated data', async () => {
+
+        // remove setTimeout because jest doesnt handle
+        // setTimeouts and promises all mixed together like this
+        let realSetTimeout = window.setTimeout;
+        window.setTimeout = (fn, ms) => fn();
+
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        parcel
+            .modifyUp(promisify('foo', ({value}) => Promise.resolve({
+                value: value + 1
+            })))
+            .set(456);
+
+        await Promise.resolve();
+
+        expect(handleChange).toHaveBeenCalledTimes(2);
+        expect(handleChange.mock.calls[1][0].value).toBe(457);
+        expect(handleChange.mock.calls[1][0].meta.fooStatus).toBe('resolved');
+        expect(handleChange.mock.calls[1][0].meta.fooError).toBe(undefined);
+
+        window.setTimeout = realSetTimeout;
+    });
+
+    it('should fire promise and reject', async () => {
+
+        // remove setTimeout because jest doesnt handle
+        // setTimeouts and promises all mixed together like this
+        let realSetTimeout = window.setTimeout;
+        window.setTimeout = (fn, ms) => fn();
+
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: 123,
+            handleChange
+        });
+
+        parcel
+            .modifyUp(promisify('foo', () => Promise.reject('error!')))
+            .set(456);
+
+        await Promise.resolve();
+
+        expect(handleChange).toHaveBeenCalledTimes(2);
+        expect(handleChange.mock.calls[1][0].value).toBe(456);
+        expect(handleChange.mock.calls[1][0].meta.fooStatus).toBe('rejected');
+        expect(handleChange.mock.calls[1][0].meta.fooError).toBe('error!');
+
+        window.setTimeout = realSetTimeout;
+    });
+
+    it('should only allow update from most recently fired promise to enforce order', async () => {
+
+        // remove setTimeout because jest doesnt handle
+        // setTimeouts and promises all mixed together like this
+        let realSetTimeout = window.setTimeout;
+        window.setTimeout = (fn, ms) => fn();
+
+        let handleChange = jest.fn();
+
+        let parcel = new Parcel({
+            value: '',
+            handleChange
+        });
+
+        let resolveFirstPromise = () => {};
+        let firstPromise = new Promise(resolve => {
+            resolveFirstPromise = () => resolve({
+                value: 'first-resolved'
+            });
+        });
+
+        let resolveSecondPromise = () => {};
+        let secondPromise = new Promise((resolve, reject) => {
+            resolveSecondPromise = () => reject('second-rejected');
+        });
+
+        let promiseUpdater = promisify('foo', ({value}) => {
+            if(value === 'first') {
+                return firstPromise;
+            }
+            if(value === 'second') {
+                return secondPromise;
+            }
+            return Promise.resolve({
+                value: 'third-resolved'
+            });
+        });
+
+        parcel
+            .modifyUp(promiseUpdater)
+            .set('first');
+
+        handleChange.mock.calls[0][0]
+            .modifyUp(promiseUpdater)
+            .set('second');
+
+        handleChange.mock.calls[1][0]
+            .modifyUp(promiseUpdater)
+            .set('third');
+
+        expect(handleChange).toHaveBeenCalledTimes(3);
+
+        await Promise.resolve();
+
+        expect(handleChange).toHaveBeenCalledTimes(4);
+        expect(handleChange.mock.calls[3][0].value).toBe('third-resolved');
+
+        resolveFirstPromise();
+        await firstPromise;
+
+        resolveSecondPromise();
+        await secondPromise.catch(() => {});
+
+        expect(handleChange).toHaveBeenCalledTimes(4);
+
+        window.setTimeout = realSetTimeout;
+    });
+});

--- a/packages/dataparcels/src/modifiers/__test__/promisify-test.js
+++ b/packages/dataparcels/src/modifiers/__test__/promisify-test.js
@@ -11,6 +11,9 @@ let allResolvedPromises = async () => {
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 };
 
 describe('promisify', () => {
@@ -270,6 +273,8 @@ describe('promisify', () => {
         resolveSecondPromise();
         await secondPromise.catch(() => {});
 
+        await allResolvedPromises();
+
         // now that 3rd has a
         expect(handleChange).toHaveBeenCalledTimes(6);
         expect(handleChange.mock.calls[3][0].value).toBe('first-resolved');
@@ -340,7 +345,6 @@ describe('promisify', () => {
 
         expect(handleChange).toHaveBeenCalledTimes(3);
 
-
         resolveThirdPromise();
         await thirdPromise;
 
@@ -349,6 +353,8 @@ describe('promisify', () => {
 
         resolveSecondPromise();
         await secondPromise.catch(() => {});
+
+        await allResolvedPromises();
 
         expect(handleChange).toHaveBeenCalledTimes(4);
         expect(handleChange.mock.calls[3][0].value).toBe('third-resolved');

--- a/packages/dataparcels/src/modifiers/promisify.js
+++ b/packages/dataparcels/src/modifiers/promisify.js
@@ -13,7 +13,14 @@ type PartialData = {
 type PromiseFunction = (data: Data) => Promise<?PartialData>;
 type Update = (updater: (data: Data) => PartialData) => void;
 
-export default (key: string, fn: PromiseFunction) => {
+type Config = {
+    key: string,
+    effect: PromiseFunction
+};
+
+export default (config: Config) => {
+    let {key} = config;
+    let fn = config.effect;
     let count = 0;
 
     return (data: Data) => {

--- a/packages/dataparcels/src/modifiers/promisify.js
+++ b/packages/dataparcels/src/modifiers/promisify.js
@@ -1,0 +1,60 @@
+// @flow
+
+type Data = {
+    value: any,
+    meta: {[key: string]: any}
+};
+
+type PartialData = {
+    value?: any,
+    meta?: {[key: string]: any}
+};
+
+type PromiseFunction = (data: Data) => Promise<?PartialData>;
+type Update = (updater: (data: Data) => PartialData) => void;
+
+export default (key: string, fn: PromiseFunction) => {
+    let count = 0;
+
+    return (data: Data) => {
+
+        let statusKey = `${key}Status`;
+        let errorKey = `${key}Error`;
+        let countAtCall = ++count;
+
+        let meta = {
+            [statusKey]: 'pending',
+            [errorKey]: undefined
+        };
+
+        let effect = (update: Update) => fn(data).then(
+            (data) => {
+                if(count !== countAtCall) return;
+                data = data || {};
+                update(() => ({
+                    ...data,
+                    meta: {
+                        // $FlowFixMe - this inference is wrong, data cannot be undefined here
+                        ...(data.meta || {}),
+                        [statusKey]: 'resolved',
+                        [errorKey]: undefined
+                    }
+                }));
+            },
+            (error) => {
+                if(count !== countAtCall) return;
+                update(() => ({
+                    meta: {
+                        [statusKey]: 'rejected',
+                        [errorKey]: error
+                    }
+                }));
+            }
+        );
+
+        return {
+            meta,
+            effect
+        };
+    };
+};

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -32,6 +32,10 @@
         "path": "arrange.js"
     },
     {
+        "limit": "0.5 KB",
+        "path": "promisify.js"
+    },
+    {
         "limit": "6.1 KB",
         "path": "translate.js"
     },

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -32,7 +32,7 @@
         "path": "arrange.js"
     },
     {
-        "limit": "0.5 KB",
+        "limit": "0.6 KB",
         "path": "promisify.js"
     },
     {

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -32,7 +32,7 @@
         "path": "arrange.js"
     },
     {
-        "limit": "0.6 KB",
+        "limit": "0.7 KB",
         "path": "promisify.js"
     },
     {

--- a/packages/react-dataparcels/__test__/Exports-test.js
+++ b/packages/react-dataparcels/__test__/Exports-test.js
@@ -9,6 +9,7 @@ import deleted from '../deleted';
 import ParcelNode from '../ParcelNode';
 import arrange from '../arrange';
 import cancel from '../cancel';
+import promisify from '../promisify';
 import translate from '../translate';
 import validation from '../validation';
 
@@ -33,6 +34,7 @@ import Internaldeleted from 'dataparcels/deleted';
 import InternalParcelNode from 'dataparcels/ParcelNode';
 import InternalAsNodes from 'dataparcels/arrange';
 import Internalcancel from 'dataparcels/cancel';
+import InternalPromisify from 'dataparcels/promisify';
 import InternalTranslate from 'dataparcels/translate';
 import InternalValidation from 'dataparcels/validation';
 
@@ -78,6 +80,10 @@ test('/arrange should export arrange', () => {
 
 test('/cancel should export cancel', () => {
     expect(cancel).toBe(Internalcancel);
+});
+
+test('/promisify should export promisify', () => {
+    expect(promisify).toBe(InternalPromisify);
 });
 
 test('/translate should export translate', () => {

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -30,6 +30,7 @@
     "useParcelBuffer.js",
     "useParcelForm.js",
     "useParcelState.js",
+    "promisify.js",
     "translate.js",
     "validation.js"
   ],

--- a/packages/react-dataparcels/promisify.js
+++ b/packages/react-dataparcels/promisify.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+module.exports = require('dataparcels/promisify.js');


### PR DESCRIPTION
*Addresses #286* 

## dataparcels

- Added `promisify` to replace `asyncValue` and `asyncChange`. The new `effect` / async change reducer make this really easy.
  - Promises responses are queued so the order of promises being resolved / rejected is predicable
- Can be used in:
  - useParcel `onChange` for async saving
  - useParcel `source` for async loading
  - useParcel / useBuffer / Boundary `derive` for async derivation such as validation
  - any `modifyUp`

```js
import promisify from 'react-dataparcels/promisify';
import useParcel from 'react-dataparcels/useParcel';

let personParcel = useParcel({
    source: () => ({
        value: 123
    }),
    onChange: promisify({
        key: 'save',
        effect: async ({value, meta}) => {
            await sendRequest(value);
            // you can return {value, meta} from here if you want to make a further update
        }
        // optionally set "last: true" if you only want to take the response from the last effect to be fired. Can be useful if you have new promises being created before old ones have resolved and you only care about the one based off the most recent value e.g. async validation of a text input
        // optionally set "revert: true" if you want it to revert changes when a promise is rejected. Useful for form submissions, as this will indicate to the buffer that it should retry sending the same changes again next time a form is submitted + any new changes
    })
});

personParcel.meta.saveStatus = 'pending' | 'resolved' | 'rejected';
personParcel.meta.saveError = latest error result, only when rejected
```