### PR TITLE
Feature/safe rebases

### DIFF
--- a/packages/dataparcels/.size-limit.json
+++ b/packages/dataparcels/.size-limit.json
@@ -20,10 +20,6 @@
         "path": "combine.js"
     },
     {
-        "limit": "0.1 KB",
-        "path": "deleted.js"
-    },
-    {
         "limit": "5.6 KB",
         "path": "ParcelNode.js"
     },

--- a/packages/dataparcels/__test__/Exports-test.js
+++ b/packages/dataparcels/__test__/Exports-test.js
@@ -5,7 +5,6 @@ import Parcel from '../src/index';
 import Action from '../Action';
 import ChangeRequest from '../ChangeRequest';
 import combine from '../combine';
-import deleted from '../deleted';
 import ParcelNode from '../ParcelNode';
 import arrange from '../arrange';
 import cancel from '../cancel';
@@ -20,7 +19,6 @@ import InternalParcel from '../src/parcel/Parcel';
 import InternalAction from '../lib/change/Action';
 import InternalChangeRequest from '../lib/change/ChangeRequest';
 import InternalCreateUpdater from '../lib/parcelData/combine';
-import Internaldeleted from '../lib/parcelData/deleted';
 import InternalParcelNode from '../lib/parcelNode/ParcelNode';
 import InternalAsNodes from '../lib/parcelNode/arrange';
 import Internalcancel from '../lib/change/cancel';
@@ -42,10 +40,6 @@ test('/ChangeRequest should export ChangeRequest', () => {
 
 test('/combine should export combine', () => {
     expect(combine).toBe(InternalCreateUpdater);
-});
-
-test('/deleted should export deleted', () => {
-    expect(deleted).toBe(Internaldeleted);
 });
 
 test('/ParcelNode should export ParcelNode', () => {

--- a/packages/dataparcels/deleted.js
+++ b/packages/dataparcels/deleted.js
@@ -1,2 +1,0 @@
-/* eslint-disable */
-module.exports = require('./lib/parcelData/deleted.js').default;

--- a/packages/dataparcels/package.json
+++ b/packages/dataparcels/package.json
@@ -16,7 +16,6 @@
     "cancel.js",
     "ChangeRequest.js",
     "combine.js",
-    "deleted.js",
     "ParcelNode.js",
     "promisify.js",
     "translate.js",

--- a/packages/dataparcels/src/change/ActionReducer.js
+++ b/packages/dataparcels/src/change/ActionReducer.js
@@ -10,6 +10,7 @@ import del from '../parcelData/delete';
 import deleteSelfWithMarker from '../parcelData/deleteSelfWithMarker';
 import insertAfter from '../parcelData/insertAfter';
 import insertBefore from '../parcelData/insertBefore';
+import isParentValue from '../parcelData/isParentValue';
 import push from '../parcelData/push';
 import setMeta from '../parcelData/setMeta';
 import setSelf from '../parcelData/setSelf';
@@ -65,9 +66,11 @@ const stepMap = {
     }
 };
 
-const doAction = ({keyPath, type, payload}: Action): ParcelDataEvaluator => {
-    let fn = actionMap[type];
-    return fn(keyPath.slice(-1)[0], payload);
+const doAction = ({keyPath, type, payload}: Action) => (parcelData: ParcelData): ParcelData => {
+    if(parentActionMap[type] && !isParentValue(parcelData.value)) {
+        return parcelData;
+    }
+    return actionMap[type](keyPath.slice(-1)[0], payload)(parcelData);
 };
 
 const doDeepAction = (action: Action): ParcelDataEvaluator => {

--- a/packages/dataparcels/src/change/ActionReducer.js
+++ b/packages/dataparcels/src/change/ActionReducer.js
@@ -7,7 +7,6 @@ import pipe from 'unmutable/lib/util/pipe';
 import findLastIndex from 'unmutable/lib/findLastIndex';
 
 import del from '../parcelData/delete';
-import deleteSelfWithMarker from '../parcelData/deleteSelfWithMarker';
 import insertAfter from '../parcelData/insertAfter';
 import insertBefore from '../parcelData/insertBefore';
 import isParentValue from '../parcelData/isParentValue';
@@ -78,10 +77,6 @@ const doDeepAction = (action: Action): ParcelDataEvaluator => {
     let isParentAction: boolean = !!(parentActionMap[type]);
 
     if(isParentAction) {
-        if(action.keyPath.length === 0) {
-            return type === "delete" ? deleteSelfWithMarker : ii => ii;
-        }
-
         let lastGetIndex = findLastIndex(step => step.type === 'get')(steps);
         steps = steps.slice(0, lastGetIndex);
     }

--- a/packages/dataparcels/src/change/ActionReducer.js
+++ b/packages/dataparcels/src/change/ActionReducer.js
@@ -35,13 +35,24 @@ const actionMap = {
     update: (lastKey, updater) => updater
 };
 
-const parentActionMap = {
+const isProcessedFromParent = {
     delete: true,
     insertAfter: true,
     insertBefore: true,
     swap: true,
     swapNext: true,
     swapPrev: true
+};
+
+const requiresParentValue = {
+    delete: true,
+    insertAfter: true,
+    insertBefore: true,
+    push: true,
+    swap: true,
+    swapNext: true,
+    swapPrev: true,
+    unshift: true
 };
 
 const stepMap = {
@@ -66,7 +77,7 @@ const stepMap = {
 };
 
 const doAction = ({keyPath, type, payload}: Action) => (parcelData: ParcelData): ParcelData => {
-    if(parentActionMap[type] && !isParentValue(parcelData.value)) {
+    if(requiresParentValue[type] && !isParentValue(parcelData.value)) {
         return parcelData;
     }
     return actionMap[type](keyPath.slice(-1)[0], payload)(parcelData);
@@ -74,9 +85,8 @@ const doAction = ({keyPath, type, payload}: Action) => (parcelData: ParcelData):
 
 const doDeepAction = (action: Action): ParcelDataEvaluator => {
     let {steps, type} = action;
-    let isParentAction: boolean = !!(parentActionMap[type]);
 
-    if(isParentAction) {
+    if(isProcessedFromParent[type]) {
         let lastGetIndex = findLastIndex(step => step.type === 'get')(steps);
         steps = steps.slice(0, lastGetIndex);
     }

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerDelete-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerDelete-test.js
@@ -2,7 +2,6 @@
 import ChangeRequest from '../ChangeRequest';
 import ActionReducer from '../ActionReducer';
 import Action from '../Action';
-import deleted from '../../parcelData/deleted';
 import pipeWith from 'unmutable/lib/util/pipeWith';
 
 test('ActionReducer should delete key', () => {
@@ -79,25 +78,4 @@ test('ActionReducer should noop if deleting deep key does nothing', () => {
     };
 
     expect(ActionReducer(action)(data).value).toEqual(expectedValue);
-});
-
-test('ActionReducer should set value to deleted symbol if deleted with no keypath', () => {
-    var data = {
-        value: {
-            a: 1,
-            b: 2
-        },
-        key: "^",
-        child: undefined
-    };
-    var action = new Action({
-        type: "delete",
-        keyPath: []
-    });
-
-    var expectedData = {
-        value: deleted
-    };
-
-    expect(ActionReducer(action)(data)).toEqual(expectedData);
 });

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerDelete-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerDelete-test.js
@@ -53,6 +53,34 @@ test('ActionReducer should delete deep key', () => {
     expect(ActionReducer(action)(data).value).toEqual(expectedValue);
 });
 
+test('ActionReducer should noop if deleting deep key does nothing', () => {
+    var data = {
+        value: {
+            a: {
+                b: 2,
+                d: 4
+            },
+            c: 3
+        },
+        key: "^",
+        child: undefined
+    };
+    var action = new Action({
+        type: "delete",
+        keyPath: ["x", "y"]
+    });
+
+    var expectedValue = {
+        a: {
+            b: 2,
+            d: 4
+        },
+        c: 3
+    };
+
+    expect(ActionReducer(action)(data).value).toEqual(expectedValue);
+});
+
 test('ActionReducer should set value to deleted symbol if deleted with no keypath', () => {
     var data = {
         value: {

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerIndexed-test.js
@@ -15,18 +15,6 @@ let EXPECTED_KEY_AND_META = {
     meta: {abc: 123}
 };
 
-[
-    "insertAfter",
-    "insertBefore",
-    "swap",
-    "swapNext",
-    "swapPrev"
-].forEach((type: string) => {
-    test(`Reducer ${type} action should return unchanged parcelData if keyPath is empty`, () => {
-        expect(ActionReducer(new Action({type}))(data)).toEqual(data);
-    });
-});
-
 const TestIndex = (arr) => arr.map(({action, expectedData}) => {
     test(`Reducer ${action.type} action should ${action.type} with keyPath ${JSON.stringify(action.keyPath)}`, () => {
         expect(ActionReducer(new Action(action))(data)).toEqual(expectedData);

--- a/packages/dataparcels/src/change/__test__/ChangeRequestReducerSet-test.js
+++ b/packages/dataparcels/src/change/__test__/ChangeRequestReducerSet-test.js
@@ -126,6 +126,23 @@ test('ActionReducer should set with keyPath of 1 element', () => {
     expect(ActionReducer(action)(data)).toEqual(expectedData);
 });
 
+test('ActionReducer should noop set with keyPath of 1 element on a non parent value', () => {
+    var data = {
+        value: 123,
+        meta: {
+            abc: 123
+        },
+        key: "^"
+    };
+    var action = new Action({
+        type: "set",
+        keyPath: ["a"],
+        payload: 3
+    });
+
+    expect(ActionReducer(action)(data)).toEqual(data);
+});
+
 test('ActionReducer should clear child from set key', () => {
     var data = {
         value: {

--- a/packages/dataparcels/src/parcel/Parcel.js
+++ b/packages/dataparcels/src/parcel/Parcel.js
@@ -20,7 +20,6 @@ import Action from '../change/Action';
 
 import isIndexedValue from '../parcelData/isIndexedValue';
 import isParentValue from '../parcelData/isParentValue';
-import deleted from '../parcelData/deleted';
 import combine from '../parcelData/combine';
 import setMetaDefault from '../parcelData/setMetaDefault';
 import prepareChildKeys from '../parcelData/prepareChildKeys';
@@ -581,7 +580,7 @@ export default class Parcel {
 
     _getValue = (notFoundValue: any): any => {
         let {value} = this;
-        return value === deleted || value === undefined
+        return value === undefined
             ? notFoundValue
             : value;
     };

--- a/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
+++ b/packages/dataparcels/src/parcel/__test__/ParcelGetMethods-test.js
@@ -1,6 +1,5 @@
 // @flow
 import Parcel from '../Parcel';
-import deleted from '../../parcelData/deleted';
 
 test('Parcel.spread() returns an object with value and set', () => {
     var data = {
@@ -27,16 +26,11 @@ test('Parcel.spread(notFoundValue) returns an object with notFoundValue', () => 
         value: undefined
     });
 
-    var parcel2 = new Parcel({
-        value: deleted
-    });
-
     var parcel3 = new Parcel({
         value: "123"
     });
 
     expect(parcel.spread("???").value).toBe("???");
-    expect(parcel2.spread("???").value).toBe("???");
     expect(parcel3.spread("???").value).toBe("123");
 });
 
@@ -65,16 +59,11 @@ test('Parcel.spreadInput(notFoundValue) returns an object with notFoundValue', (
         value: undefined
     });
 
-    var parcel2 = new Parcel({
-        value: deleted
-    });
-
     var parcel3 = new Parcel({
         value: "123"
     });
 
     expect(parcel.spreadInput("???").value).toBe("???");
-    expect(parcel2.spreadInput("???").value).toBe("???");
     expect(parcel3.spreadInput("???").value).toBe("123");
 });
 

--- a/packages/dataparcels/src/parcelData/deleteSelfWithMarker.js
+++ b/packages/dataparcels/src/parcelData/deleteSelfWithMarker.js
@@ -1,6 +1,0 @@
-// @flow
-import deleted from './deleted';
-
-export default () => ({
-    value: deleted
-});

--- a/packages/dataparcels/src/parcelData/update.js
+++ b/packages/dataparcels/src/parcelData/update.js
@@ -25,6 +25,10 @@ export default (key: Key|Index, updater: Function) => (parcelData: ParcelData): 
         return parcelDataWithChildKeys;
     }
 
+    if(!isParentValue(parcelDataWithChildKeys.value)) {
+        return parcelData;
+    }
+
     let updatedData = has(key)(parcelDataWithChildKeys)
         ? pipeWith(
             parcelDataWithChildKeys,

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -20,10 +20,6 @@
         "path": "combine.js"
     },
     {
-        "limit": "0.1 KB",
-        "path": "deleted.js"
-    },
-    {
         "limit": "5.6 KB",
         "path": "ParcelNode.js"
     },

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -1,6 +1,6 @@
 [
     {
-        "limit": "10.3 KB",
+        "limit": "10.4 KB",
         "path": "lib/index.js"
     },
     {
@@ -12,7 +12,7 @@
         "path": "cancel.js"
     },
     {
-        "limit": "7.3 KB",
+        "limit": "7.4 KB",
         "path": "ChangeRequest.js"
     },
     {
@@ -28,7 +28,7 @@
         "path": "ParcelNode.js"
     },
     {
-        "limit": "5.9 KB",
+        "limit": "6.0 KB",
         "path": "arrange.js"
     },
     {
@@ -68,11 +68,11 @@
         "path": "useParcelBuffer.js"
     },
     {
-        "limit": "13.3 KB",
+        "limit": "13.4 KB",
         "path": "useParcelForm.js"
     },
     {
-        "limit": "10.8 KB",
+        "limit": "10.9 KB",
         "path": "useParcelState.js"
     },
     {

--- a/packages/react-dataparcels/__test__/Exports-test.js
+++ b/packages/react-dataparcels/__test__/Exports-test.js
@@ -5,7 +5,6 @@ import Parcel from '../src/index';
 import Action from '../Action';
 import ChangeRequest from '../ChangeRequest';
 import combine from '../combine';
-import deleted from '../deleted';
 import ParcelNode from '../ParcelNode';
 import arrange from '../arrange';
 import cancel from '../cancel';
@@ -30,7 +29,6 @@ import InternalParcel from 'dataparcels';
 import InternalAction from 'dataparcels/Action';
 import InternalChangeRequest from 'dataparcels/ChangeRequest';
 import InternalCreateUpdater from 'dataparcels/combine';
-import Internaldeleted from 'dataparcels/deleted';
 import InternalParcelNode from 'dataparcels/ParcelNode';
 import InternalAsNodes from 'dataparcels/arrange';
 import Internalcancel from 'dataparcels/cancel';
@@ -64,10 +62,6 @@ test('/ChangeRequest should export ChangeRequest', () => {
 
 test('/combine should export combine', () => {
     expect(combine).toBe(InternalCreateUpdater);
-});
-
-test('/deleted should export deleted', () => {
-    expect(deleted).toBe(Internaldeleted);
 });
 
 test('/ParcelNode should export ParcelNode', () => {

--- a/packages/react-dataparcels/deleted.js
+++ b/packages/react-dataparcels/deleted.js
@@ -1,2 +1,0 @@
-/* eslint-disable */
-module.exports = require('dataparcels/deleted.js');

--- a/packages/react-dataparcels/package.json
+++ b/packages/react-dataparcels/package.json
@@ -20,7 +20,6 @@
     "cancel.js",
     "ChangeRequest.js",
     "combine.js",
-    "deleted.js",
     "ParcelBoundary.js",
     "ParcelDrag.js",
     "ParcelNode.js",

--- a/packages/react-dataparcels/src/__test__/useBuffer-test.js
+++ b/packages/react-dataparcels/src/__test__/useBuffer-test.js
@@ -88,6 +88,56 @@ describe('useBuffer source', () => {
         // inner parcel should have sources value
         expect(result.current.value).toEqual(456);
     });
+
+    it('should pass new inner parcel if source is different, and reapply buffered actions', () => {
+
+        let source = new Parcel({
+            value: [1]
+        });
+
+        let {result, rerender} = renderHookWithProps({source}, ({source}) => useBuffer({source, buffer: true}));
+
+        act(() => {
+            result.current.push(2);
+            result.current.push(3);
+        });
+
+        act(() => {
+            rerender({
+                source: new Parcel({
+                    value: [0]
+                })
+            });
+        });
+
+        expect(result.current.value).toEqual([0,2,3]);
+    });
+
+    it('should pass new inner parcel if source is different, and only reapply buffered actions that can be applied', () => {
+
+        let source = new Parcel({
+            value: [[],[]]
+        });
+
+        let {result, rerender} = renderHookWithProps({source}, ({source}) => useBuffer({source, buffer: true}));
+
+        act(() => {
+            result.current.get(0).push(0);
+            result.current.get(1).push(1);
+        });
+
+        expect(result.current.value).toEqual([[0],[1]]);
+
+        act(() => {
+            rerender({
+                source: new Parcel({
+                    value: [null, []]
+                })
+            });
+        });
+
+        expect(result.current.value).toEqual([null,[1]]);
+    });
 });
 
 describe('useBuffer buffer', () => {

--- a/packages/react-dataparcels/src/useBuffer.js
+++ b/packages/react-dataparcels/src/useBuffer.js
@@ -102,7 +102,10 @@ export default (params: Params): Parcel => {
 
         innerParcel = source
             ._boundarySplit({handleChange})
-            .modifyDown(derive);
+            .modifyDown(derive)
+            .pipe(parcel => bufferState.reduce((accParcel, changeRequest) => {
+                return accParcel._changeAndReturn(pp => pp.dispatch(changeRequest))[0];
+            }, parcel));
 
         setInnerParcel(innerParcel);
     }


### PR DESCRIPTION
*Addresses #211*

## dataparcels

- **BREAKING CHANGE** removed `deleted` marker
  - this would appear as the value when deleting the top level data structure, however chances are that this won't actually break anything because the Parcel API hasn't allowed this kind of action for over a year, and direct creation of actions has been discouraged for even longer
- fix: make all actions safely noop if they cant work
  - invalid actions can come about from rebasing, where actions performed on one data shape are applied to another data shape, perhaps because the data shape updated in the background
  - e.g. deleting keyPath ["a","b"] from `123`, or inserting something after `#z` where `#z` no longer exists
  - in future perhaps there might need to be a way to choose how to handle these merge conflicts. For now these actions will not have any effect if they no longer make sense, which to be honest ends up a little like 2 people typing the same word at the same time in google docs - somebody wins.

## react-dataparcels

- **BREAKING CHANGE** removed `deleted` marker
- amend: make `useBuffer` (and therefore `useParcel`) rebase existing actions onto new base data by default