### PR TITLE
Feature/revert

### DIFF
--- a/packages/dataparcels-docs/src/pages/dev.js
+++ b/packages/dataparcels-docs/src/pages/dev.js
@@ -55,12 +55,10 @@ export default function PersonEditor() {
                         saves: value.saves + 1
                     }
                 };
-            },
-            revert: true
+            }
         }),
         dependencies: [dep],
-        buffer: true,
-        history: 100
+        buffer: true
     });
 
     return <Page>

--- a/packages/dataparcels/src/modifiers/__test__/promisify-test.js
+++ b/packages/dataparcels/src/modifiers/__test__/promisify-test.js
@@ -170,38 +170,6 @@ describe('promisify', () => {
         window.setTimeout = realSetTimeout;
     });
 
-    it('should fire promise and reject and revert', async () => {
-
-        // remove setTimeout because jest doesnt handle
-        // setTimeouts and promises all mixed together like this
-        let realSetTimeout = window.setTimeout;
-        window.setTimeout = (fn, ms) => fn();
-
-        let handleChange = jest.fn();
-
-        let parcel = new Parcel({
-            value: 123,
-            handleChange
-        });
-
-        parcel
-            .modifyUp(promisify({
-                key: 'foo',
-                effect: () => Promise.reject('error!'),
-                revert: true
-            }))
-            .set(456);
-
-        await allResolvedPromises();
-
-        expect(handleChange).toHaveBeenCalledTimes(2);
-        expect(handleChange.mock.calls[1][0].value).toBe(123);
-        expect(handleChange.mock.calls[1][0].meta.fooStatus).toBe('rejected');
-        expect(handleChange.mock.calls[1][0].meta.fooError).toBe('error!');
-
-        window.setTimeout = realSetTimeout;
-    });
-
     it('should process results in the same order they were fired', async () => {
 
         // remove setTimeout because jest doesnt handle

--- a/packages/dataparcels/src/modifiers/promisify.js
+++ b/packages/dataparcels/src/modifiers/promisify.js
@@ -21,12 +21,11 @@ type PromiseFunction = (data: Data) => Promise<?PartialData|Updater>;
 type Config = {
     key: string,
     effect: PromiseFunction,
-    revert?: boolean,
     last?: boolean
 };
 
 export default (config: Config): Updater => {
-    let {key, revert, last} = config;
+    let {key, last} = config;
     let fn = config.effect;
     let count = 0;
     let chain = Promise.resolve();
@@ -49,11 +48,6 @@ export default (config: Config): Updater => {
                 .then(data => lastChain.then((): any => data))
                 .then(({result, error}) => {
                     if(last && count !== countAtCall) return;
-
-                    if(error) {
-                        result = revert ? data.changeRequest.prevData : {};
-                    }
-
                     update(combine(
                         typeof result !== 'function' ? () => result : result,
                         () => ({

--- a/packages/dataparcels/src/modifiers/promisify.js
+++ b/packages/dataparcels/src/modifiers/promisify.js
@@ -25,13 +25,13 @@ type Config = {
     last?: boolean
 };
 
-export default (config: Config) => {
+export default (config: Config): Updater => {
     let {key, revert, last} = config;
     let fn = config.effect;
     let count = 0;
     let chain = Promise.resolve();
 
-    return (data: Data) => {
+    let updater = (data: Data): PartialData => {
 
         let statusKey = `${key}Status`;
         let errorKey = `${key}Error`;
@@ -71,4 +71,7 @@ export default (config: Config) => {
             effect
         };
     };
+
+    updater.revertKey = key;
+    return updater;
 };

--- a/packages/react-dataparcels/.size-limit.json
+++ b/packages/react-dataparcels/.size-limit.json
@@ -48,7 +48,7 @@
         "path": "asyncChange.js"
     },
     {
-        "limit": "12.1 KB",
+        "limit": "12.2 KB",
         "path": "Boundary.js"
     },
     {
@@ -72,11 +72,11 @@
         "path": "useParcelState.js"
     },
     {
-        "limit": "12.3 KB",
+        "limit": "12.4 KB",
         "path": "useParcel.js"
     },
     {
-        "limit": "12.0 KB",
+        "limit": "12.1 KB",
         "path": "useBuffer.js"
     }
 ]

--- a/packages/react-dataparcels/src/useParcel.js
+++ b/packages/react-dataparcels/src/useParcel.js
@@ -81,7 +81,8 @@ export default (params: Params): Parcel => {
         source: preparedParcel,
         buffer,
         history,
-        derive
+        derive,
+        revertKey: onChange.revertKey
     });
 
     return bufferedParcel;


### PR DESCRIPTION
- Remove `promisify` revert - not needed now buffers can deal with history in a better way
- Add `useBuffer` `revertKey`, to nominate a request state key that's made by a `promisify`, and if it has one then it'll keep recently submitted changes hanging around until the status says its resolved, and roll back submissions where the status says it rejected.
- `useParcel` combines an `onChange` (with possible `promisify`) with a `useBuffer`, so it can tie those together by their revertKey automatically